### PR TITLE
Typecraft: Fixed a potential bug in io/typecraft.py

### DIFF
--- a/src/poioapi/io/typecraft.py
+++ b/src/poioapi/io/typecraft.py
@@ -730,7 +730,7 @@ class Writer(poioapi.io.graf.BaseWriter):
             splitter = '.'
             # Special gloss value
             if "?" in annotation and annotation != "?IPFV":
-                return None
+                continue
 
             # Select the splitter for the gloss values
             if ":" in annotation:


### PR DESCRIPTION
In the Writer#missing_tags method, the gloss-node validator exited the
method if it found an annotation containing the letter '?'. This I
assume is a bug, and the proper behaviour is to continue the loop.

The consequence of the before-behaviour is that a file of the
mappings never get generated.

If it is not a bug, I am assuming it is part of some specification I am
unaware of. In any case, it currently breaks the importation-process of
toolbox-items into the typecraft system. This can of course be regarded
as a bug in the typecraft system, and can definitely be altered. But I
am not so sure it shouldn't be considered a bug in Poio instead.